### PR TITLE
4-duplication-rate

### DIFF
--- a/src/Duplication/FAMIXSourcedEntity.extension.st
+++ b/src/Duplication/FAMIXSourcedEntity.extension.st
@@ -53,24 +53,28 @@ FAMIXSourcedEntity >> duplicationRate [
 		ifEmpty: [ 0 ]
 		ifNotEmpty: [ :cloneLocations | 
 			| accumulator usefulCloneLocations |
-			accumulator := 0.	
-				
+			accumulator := 0.
+
 			"We remove the localisations already included in other localisations because this add noise."
 			usefulCloneLocations := cloneLocations
 				inject: OrderedCollection new
 				into: [ :res :cl | 
-					res detect: [ :loc | loc includesLocation: cl ] ifNone: [ res add: cl ].
-					res ].	
-					
+					res
+						detect: [ :loc | loc includesLocation: cl ]
+						ifNone: [ res add: cl ].
+					res ].
+
 			"We sort the fragments by startline to get the contiguous next to each other."
 			usefulCloneLocations sort: [ :a :b | a startLine < b startLine ].
 			usefulCloneLocations allButLast
 				do: [ :aLocation | 
 					(aLocation contiguousWith: (usefulCloneLocations after: aLocation))
-						ifTrue: [ accumulator := accumulator + (usefulCloneLocations after: aLocation) startLine - aLocation startLine ]
+						ifTrue: [ accumulator := accumulator
+								+ (usefulCloneLocations after: aLocation) startLine
+								- aLocation startLine ]
 						ifFalse: [ accumulator := accumulator + aLocation length ] ].
 			accumulator := accumulator + usefulCloneLocations last length.
-			accumulator / self numberOfLinesOfCode ]
+			accumulator asString , '/' , self sourceText lineCount asString ]
 ]
 
 { #category : #'*Duplication' }

--- a/src/Duplication/MooseEntity.extension.st
+++ b/src/Duplication/MooseEntity.extension.st
@@ -42,19 +42,35 @@ MooseEntity >> duplicatedSourceText [
 
 { #category : #'*Duplication' }
 MooseEntity >> duplicationRate [
-  < MSEProperty: #duplicationRate type: #Number>
-  < MSEComment: 'Duplication Rate.'>
-  < derived>
-  ^self cloneLocations ifEmpty: [ 0 ] ifNotEmpty: [:cloneLocations |  | accumulator usefulCloneLocations |
-        accumulator := 0.
-        
-        "We remove the localisations already included in other localisations because this add noise."usefulCloneLocations := cloneLocations inject: OrderedCollection new into: [:res :cl |  res detect: [:loc |  loc includesLocation: cl ] ifNone: [ res add: cl ].
-              res ].
-        
-        "We sort the fragments by startline to get the contiguous next to each other."usefulCloneLocations sort: [:a :b |  a startLine < b startLine ].
-        usefulCloneLocations allButLast do: [:aLocation |  (aLocation contiguousWith: (usefulCloneLocations after: aLocation)) ifTrue: [ accumulator := accumulator + (usefulCloneLocations after: aLocation) startLine - aLocation startLine ] ifFalse: [ accumulator := accumulator + aLocation length ] ].
-        accumulator := accumulator + usefulCloneLocations last length.
-        accumulator / self numberOfLinesOfCode ]
+	<MSEProperty: #duplicationRate type: #Number>
+	<MSEComment: 'Duplication Rate.'>
+	<derived>
+	^ self cloneLocations
+		ifEmpty: [ 0 ]
+		ifNotEmpty: [ :cloneLocations | 
+			| accumulator usefulCloneLocations |
+			accumulator := 0.
+
+			"We remove the localisations already included in other localisations because this add noise."
+			usefulCloneLocations := cloneLocations
+				inject: OrderedCollection new
+				into: [ :res :cl | 
+					res
+						detect: [ :loc | loc includesLocation: cl ]
+						ifNone: [ res add: cl ].
+					res ].
+
+			"We sort the fragments by startline to get the contiguous next to each other."
+			usefulCloneLocations sort: [ :a :b | a startLine < b startLine ].
+			usefulCloneLocations allButLast
+				do: [ :aLocation | 
+					(aLocation contiguousWith: (usefulCloneLocations after: aLocation))
+						ifTrue: [ accumulator := accumulator
+								+ (usefulCloneLocations after: aLocation) startLine
+								- aLocation startLine ]
+						ifFalse: [ accumulator := accumulator + aLocation length ] ].
+			accumulator := accumulator + usefulCloneLocations last length.
+			accumulator asString , '/' , self sourceText lineCount asString ]
 ]
 
 { #category : #'*Duplication' }

--- a/src/Duplication/MooseModel.extension.st
+++ b/src/Duplication/MooseModel.extension.st
@@ -6,18 +6,6 @@ MooseModel >> dupDetectionParams [
 ]
 
 { #category : #'*Duplication' }
-MooseModel >> duplicationRate [
-	"I return a metric that correspond to the percentage of duplication in the code."
-
-	^ self
-		lookUpPropertyNamed: #duplicationRate
-		computedAs: [ 
-			[ self entitiesForDupDetection average: #duplicationRate ]
-				on: ZeroDivide
-				do: [ SYNUnavailableMetric  ] ]
-]
-
-{ #category : #'*Duplication' }
 MooseModel >> entitiesForDupDetection [
 	^ self allContainers
 ]


### PR DESCRIPTION
There is a problem in the way duplication rate is computed. In fact a duplicated code can contain empty lines. So by considering only lines of codes, there is a biais .Use string instead of calculating  actual float valuefix #4